### PR TITLE
DB rp empirical

### DIFF
--- a/exploration/04_add_return_periods_example.py
+++ b/exploration/04_add_return_periods_example.py
@@ -8,6 +8,10 @@
 #       format_name: percent
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: hdx-floodscan
+#     language: python
+#     name: hdx-floodscan
 # ---
 
 # %%
@@ -15,13 +19,11 @@
 # %load_ext autoreload
 # %autoreload 2
 
+import numpy as np
+
 # %%
 from src.utils import pg
 from src.utils import return_periods as rp
-
-# import pandas as pd
-# import numpy as np
-# from scipy.interpolate import interp1d
 
 # %%
 df_current = pg.fs_last_90_days(mode="prod", admin_level=2, band="SFED")
@@ -31,3 +33,16 @@ df_yr_max = pg.fs_year_max(mode="prod", admin_level=2, band="SFED")
 df_w_rps = rp.fs_add_rp(
     df=df_current, df_maxima=df_yr_max, by=["iso3", "pcode"]
 )
+
+# %% [markdown]
+# we can have a metadata tab + table that explains why the admin below are not
+# included
+
+# %%
+rp.extract_nan_strata(df_current, by=["iso3", "pcode"])
+
+# %%
+
+max_rp = df_w_rps["RP"].max()
+max_rp = df_w_rps[df_w_rps["RP"] != np.inf]["RP"].max()
+print(max_rp)

--- a/exploration/04_add_return_periods_example.py
+++ b/exploration/04_add_return_periods_example.py
@@ -1,0 +1,33 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+# ---
+
+# %%
+# %matplotlib inline
+# %load_ext autoreload
+# %autoreload 2
+
+# %%
+from src.utils import pg
+from src.utils import return_periods as rp
+
+# import pandas as pd
+# import numpy as np
+# from scipy.interpolate import interp1d
+
+# %%
+df_current = pg.fs_last_90_days(mode="prod", admin_level=2, band="SFED")
+df_yr_max = pg.fs_year_max(mode="prod", admin_level=2, band="SFED")
+
+# %%
+df_w_rps = rp.fs_add_rp(
+    df=df_current, df_maxima=df_yr_max, by=["iso3", "pcode"]
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ scipy==1.14.1
 lmoments3==1.0.7
 pyarrow==17.0.0
 SQLAlchemy==2.0.33
+psycopg2==2.9.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ netCDF4==1.7.2
 scipy==1.14.1
 lmoments3==1.0.7
 pyarrow==17.0.0
+SQLAlchemy==2.0.33

--- a/src/datasources/pg.py
+++ b/src/datasources/pg.py
@@ -1,0 +1,65 @@
+import os
+
+import pandas as pd
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+
+load_dotenv()
+
+AZURE_DB_PW_PROD = os.getenv("AZURE_DB_PW_PROD")
+AZURE_DB_PW_DEV = os.getenv("AZURE_DB_PW_DEV")
+
+
+def fs_year_max(mode, admin_level, band="SFED"):
+    engine = get_engine(mode)
+
+    query_yr_max = f"""
+        SELECT iso3, pcode, DATE_TRUNC('year', valid_date) AS year_date, MAX(mean) AS value
+        FROM floodscan
+        WHERE adm_level = {admin_level}
+          AND band = '{band}'
+          AND valid_date <= '2023-12-31'
+        GROUP BY iso3, pcode, year_date
+    """
+    pd.read_sql(sql=query_yr_max, con=engine)
+
+
+def fs_last_90_days(mode, admin_level, band="SFED"):
+    engine = get_engine(mode)
+
+    query_last_90_days = f"""
+    SELECT iso3, pcode, valid_date, mean AS value
+    FROM floodscan
+    WHERE adm_level = {admin_level}
+      AND band = '{band}'
+      AND valid_date >= NOW() - INTERVAL '90 days'
+    """
+    return pd.read_sql(sql=query_last_90_days, con=engine)
+
+
+def get_engine(mode):
+    if mode == "prod":
+        url = f"postgresql+psycopg2://chdadmin:{AZURE_DB_PW_PROD}@chd-rasterstats-prod.postgres.database.azure.com/postgres"  # noqa: E501 E231
+    else:
+        url = f"postgresql+psycopg2://chdadmin:{AZURE_DB_PW_DEV}@chd-rasterstats-dev.postgres.database.azure.com/postgres"  # noqa: E501 E231
+    return create_engine(url)
+
+
+# this one is experimental - may mess around and see how it works on prod
+def create_yr_max_view(mode):
+    engine = get_engine(mode)
+    with engine.connect() as conn:
+        query = """
+            CREATE OR REPLACE VIEW floodscan_yearly_max AS
+            SELECT iso3, pcode, year_date, MAX(mean) AS value
+            FROM (
+                SELECT iso3, pcode, adm_level, valid_date, band, mean,
+                       DATE_TRUNC('year', valid_date) AS year_date
+                FROM floodscan
+                WHERE adm_level = 2
+                  AND band = 'SFED'
+                  AND valid_date <= '2023-12-31'
+            ) AS filtered_floodscan
+            GROUP BY iso3, pcode, year_date
+        """
+        conn.execute(query)

--- a/src/datasources/pg.py
+++ b/src/datasources/pg.py
@@ -46,20 +46,20 @@ def get_engine(mode):
 
 
 # this one is experimental - may mess around and see how it works on prod
-def create_yr_max_view(mode):
+def create_yr_max_view(mode, admin_level, band):
     engine = get_engine(mode)
     with engine.connect() as conn:
-        query = """
+        query = f"""
             CREATE OR REPLACE VIEW floodscan_yearly_max AS
             SELECT iso3, pcode, year_date, MAX(mean) AS value
             FROM (
                 SELECT iso3, pcode, adm_level, valid_date, band, mean,
                        DATE_TRUNC('year', valid_date) AS year_date
                 FROM floodscan
-                WHERE adm_level = 2
-                  AND band = 'SFED'
+                WHERE adm_level = {admin_level}
+                  AND band = '{band}'
                   AND valid_date <= '2023-12-31'
             ) AS filtered_floodscan
             GROUP BY iso3, pcode, year_date
-        """
+        """  # noqa E231 E202
         conn.execute(query)

--- a/src/utils/pg.py
+++ b/src/utils/pg.py
@@ -10,6 +10,16 @@ AZURE_DB_PW_PROD = os.getenv("AZURE_DB_PW_PROD")
 AZURE_DB_PW_DEV = os.getenv("AZURE_DB_PW_DEV")
 
 
+def get_engine(mode):
+    if mode == "prod":
+        pw = AZURE_DB_PW_PROD
+    else:
+        pw = AZURE_DB_PW_DEV
+
+    url = f"postgresql+psycopg2://chdadmin:{pw}@chd-rasterstats-{mode}.postgres.database.azure.com/postgres"  # noqa: E501 E231
+    return create_engine(url)
+
+
 def fs_year_max(mode, admin_level, band="SFED"):
     engine = get_engine(mode)
 
@@ -21,7 +31,7 @@ def fs_year_max(mode, admin_level, band="SFED"):
           AND valid_date <= '2023-12-31'
         GROUP BY iso3, pcode, year_date
     """
-    pd.read_sql(sql=query_yr_max, con=engine)
+    return pd.read_sql(sql=query_yr_max, con=engine)
 
 
 def fs_last_90_days(mode, admin_level, band="SFED"):
@@ -35,14 +45,6 @@ def fs_last_90_days(mode, admin_level, band="SFED"):
       AND valid_date >= NOW() - INTERVAL '90 days'
     """
     return pd.read_sql(sql=query_last_90_days, con=engine)
-
-
-def get_engine(mode):
-    if mode == "prod":
-        url = f"postgresql+psycopg2://chdadmin:{AZURE_DB_PW_PROD}@chd-rasterstats-prod.postgres.database.azure.com/postgres"  # noqa: E501 E231
-    else:
-        url = f"postgresql+psycopg2://chdadmin:{AZURE_DB_PW_DEV}@chd-rasterstats-dev.postgres.database.azure.com/postgres"  # noqa: E501 E231
-    return create_engine(url)
 
 
 # this one is experimental - may mess around and see how it works on prod

--- a/src/utils/return_periods.py
+++ b/src/utils/return_periods.py
@@ -14,12 +14,12 @@ def fs_add_rp(df, df_maxima, by):
 
     df_filt = df[
         ~df[by].apply(tuple, axis=1).isin(df_nans.apply(tuple, axis=1))
-    ]
+    ].copy()
     df_maxima_filt = df_maxima[
         ~df_maxima[by]
         .apply(tuple, axis=1)
         .isin(df_maxima_nans.apply(tuple, axis=1))
-    ]
+    ].copy()
 
     df_rps = (
         df_maxima_filt.groupby(by, group_keys=True)


### PR DESCRIPTION
add empirical RP simplification functions.

- I've added functions to calculate empirical RPs to `src/utils/return_periods.py`
- An example of the implementation is shown in `exploration/04_add_return_periods_example.py`

I've kept the loading functions and processing functions separate for flexibility in how the pipeline will be configured/parameterized.

