### PR TITLE
correct `np.inf` values & dealing w/ `nan`

### DIFF
--- a/exploration/04_add_return_periods_example.py
+++ b/exploration/04_add_return_periods_example.py
@@ -19,9 +19,9 @@
 # %load_ext autoreload
 # %autoreload 2
 
+# %%
 import numpy as np
 
-# %%
 from src.utils import pg
 from src.utils import return_periods as rp
 
@@ -46,3 +46,14 @@ rp.extract_nan_strata(df_current, by=["iso3", "pcode"])
 max_rp = df_w_rps["RP"].max()
 max_rp = df_w_rps[df_w_rps["RP"] != np.inf]["RP"].max()
 print(max_rp)
+
+# %% [markdown]
+# Good no longer any NA/NAN values being produced and instead they are
+# correctly set as `Inf`
+#
+
+# %%
+df_w_rps[df_w_rps.RP.isna()]
+
+# %%
+df_w_rps[np.isinf(df_w_rps["RP"])]

--- a/exploration/07_informing_user_of_NA.py
+++ b/exploration/07_informing_user_of_NA.py
@@ -1,0 +1,59 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: hdx-floodscan
+#     language: python
+#     name: hdx-floodscan
+# ---
+
+# %%
+# %matplotlib inline
+# %load_ext autoreload
+# %autoreload 2
+
+# %% [markdown]
+# The purpose of this notebook is to examine and discuss how we want to deal
+# with `NA`/ `NAN` values in the data.
+#
+# Driver: Our understanding is that these are a result our zonal statistics
+# methodology which uses raster resampling. In some cases the resampled
+# resolution is too coarse for very small admin boundary units admins
+# boundaries with no pixel centroids are present. These therefore have `NaN`
+# values in the `value` column of our prod database. You can see more on this
+# discussed in relations to this project
+# [here](https://github.com/OCHA-DAP/ds-raster-stats/issues/28) and
+# [here](https://github.com/OCHA-DAP/ds-raster-stats/issues/20).
+#
+# Anyways we can continue to discuss options in the issues above, but i wanted
+# to provide this notebook so that we can see the extent of the problem and
+# refer to it there.
+
+# %%
+from src.utils import pg
+from src.utils import return_periods as rp
+
+# %%
+df_adm2 = pg.fs_last_90_days(mode="prod", admin_level=2, band="SFED")
+df_adm1 = pg.fs_last_90_days(mode="prod", admin_level=1, band="SFED")
+
+# %% [markdown]
+# Here is the issue at the admin 2 level
+
+# %%
+rp.extract_nan_strata(df_adm2, by=["iso3", "pcode"])
+
+
+# %% [markdown]
+# And also the admin 1 level. However, I suppose that these are not HRP
+# countries so not directly relevant/ an issue for this project at this stage.
+
+# %%
+rp.extract_nan_strata(df_adm1, by=["iso3", "pcode"])

--- a/exploration/07_informing_user_of_NA.py
+++ b/exploration/07_informing_user_of_NA.py
@@ -36,9 +36,10 @@
 # to provide this notebook so that we can see the extent of the problem and
 # refer to it there.
 
-import pandas as pd
 
 # %%
+import pandas as pd
+
 from src.utils import pg
 from src.utils import return_periods as rp
 
@@ -102,4 +103,11 @@ df_sfed_missing
 
 # %%
 df_w_rps_complete = pd.concat([df_w_rps, df_sfed_missing], ignore_index=True)
-df_w_rps_complete
+
+
+# %% [markdown]
+# make sure the classification counts make sense
+
+# %%
+rp_class_counts = df_w_rps_complete["RP"].value_counts(dropna=False)
+rp_class_counts

--- a/src/utils/return_periods.py
+++ b/src/utils/return_periods.py
@@ -37,7 +37,10 @@ def fs_add_rp(df, df_maxima, by):
         axis=1,
     ).astype(float)
 
-    df_filt.loc[:, "RP"] = clean_rps(df_filt["RP"], decimals=3, upper=10)
+    df_filt.loc[:, "RP"] = df_filt["RP"].astype(float)
+    df_filt.loc[:, "RP_class"] = reclassify_rp(df_filt["RP"])
+    df_filt = df_filt.drop(columns=["RP"])
+    df_filt = df_filt.rename(columns={"RP_class": "RP"})
 
     return df_filt
 
@@ -89,10 +92,12 @@ def apply_interp(row, interp_dict, by=["iso3", "pcode"]):
         return np.nan
 
 
-def clean_rps(x, decimals=3, upper=10):
-    x_round = x.round(3)
-    x_round[x_round > upper] = np.inf
-    return x_round
+def reclassify_rp(x):
+    # start bins below lowest values so we can set right = True which
+    # by default makes left = False. Otherwise 1 turns to NaN
+    bins = [0.9, 1.5, 2, 3, 4, 5, 7, 10, np.inf]
+    labels = ["1-1.5", "1.5-2", "2-3", "3-4", "4-5", "5-7", "7-10", ">10"]
+    return pd.cut(x, bins=bins, labels=labels, right=True)
 
 
 def empirical_rp(group):

--- a/src/utils/return_periods.py
+++ b/src/utils/return_periods.py
@@ -70,7 +70,7 @@ def interpolation_functions_by(df, rp, value, by=["iso3", "pcode"]):
                 group[value],
                 group[rp],
                 bounds_error=False,
-                fill_value=(1, np.nan),
+                fill_value=(1, np.inf),
             ),
             include_groups=False,
         )


### PR DESCRIPTION
## Infinity values

- I noticed too many blank values in the excel output on the jira stage so I decided it was better to more explicitly set the upper range as `np.inf` in the empirical rp interpolation function
- This seems to take care of it as noted in the update to `exploration/add_return_periods.py`

## nan values

@t-downing @hannahker 

- This relates to https://github.com/OCHA-DAP/ds-raster-stats/issues/20 & https://github.com/OCHA-DAP/ds-raster-stats/issues/28 , but moving those issues here as we need to discuss and deal with it specifically for this project
- I've shown how the problem will affect this output in notebook `exploration/07_informing_user_of_NA.py`, but i think it would be good to discuss options for presenting this information. @hannahker  wrote a nice succinct disclaimer that we can use/modify with any of the options [here](https://github.com/OCHA-DAP/ds-raster-stats/issues/20#issuecomment-2505017207)

### Options:

1. We exclude them from the tabular excel data set  and include a metadata table that contains the admin missing admins either in the readme or in another tab. Then we need to put some sort of disclaimer like hannahs.
2. We keep the admins in with blank SFED values and then include a disclaimer

I like option 2 as it avoids both the need to update a table in the in readme as well as placing an outsized emphasis on this relatively smally issue. I think it will also make the ultimate disclaimer less wordy.

@isatotun  -  i think the implementation of option 2 is also pretty straight forward to implement in the notebook and have added one implementation of it to the bottom of `exploration/07_informing_user_of_NA.py`

Also l latest version of sample readme is on the [Jira ticket](https://humanitarian.atlassian.net/browse/HDXDSYS-1460)


